### PR TITLE
Change sideband database to reference on thread IDs rather than address.

### DIFF
--- a/QKSMS/src/main/java/com/moez/QKSMS/data/MessageSidebandDBHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/data/MessageSidebandDBHelper.java
@@ -11,7 +11,7 @@ public class MessageSidebandDBHelper extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "smishing_sideband.db";
 
     //Database version
-    private static final int DATABASE_VERSION = 1;
+    private static final int DATABASE_VERSION = 2;
 
     //Table names
     public static final String TABLE_NAME_SIDEBANDDB = "sms_sideband_db";
@@ -20,13 +20,15 @@ public class MessageSidebandDBHelper extends SQLiteOpenHelper {
     //sms_sideband_db columns
     public static final String SIDEBAND_COLUMN_ID = "_id";
     public static final String SIDEBAND_COLUMN_MESSAGEDB_ID = "messagedb_id";
+    public static final String SIDEBAND_COLUMN_THREAD_ID = "thread_id";
     public static final String SIDEBAND_COLUMN_ADDRESSEE = "addressee";
     public static final String SIDEBAND_COLUMN_EXTRAINFO = "smishing_marked_as";
     public static final String SIDEBAND_COLUMN_SENT_TO_UW = "sent_to_uw";
 
     //sms_privacy_db columns
     public static final String PRIVACY_COLUMN_ID = "_id";
-    public static final String PRIVACY_COLUMN_ADDRESSEE = "addressee";
+    //public static final String PRIVACY_COLUMN_ADDRESSEE = "addressee";
+    public static final String PRIVACY_COLUMN_THREAD_ID = "thread_id";
 
     //Table Create Statements
     //sms_sideband_db create
@@ -35,6 +37,7 @@ public class MessageSidebandDBHelper extends SQLiteOpenHelper {
                     SIDEBAND_COLUMN_ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
                     SIDEBAND_COLUMN_ADDRESSEE + " TEXT," +
                     SIDEBAND_COLUMN_MESSAGEDB_ID + " TEXT," +
+                    SIDEBAND_COLUMN_THREAD_ID + " INTEGER," +
                     SIDEBAND_COLUMN_EXTRAINFO + " TEXT," +
                     SIDEBAND_COLUMN_SENT_TO_UW + " TEXT DEFAULT '0')";
 
@@ -42,7 +45,8 @@ public class MessageSidebandDBHelper extends SQLiteOpenHelper {
     private static final String TABLE_PRIVACYDB_CREATE =
             "CREATE TABLE " + TABLE_NAME_PRIVACYDB + " (" +
                     PRIVACY_COLUMN_ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
-                    PRIVACY_COLUMN_ADDRESSEE + " TEXT NOT NULL UNIQUE)";
+                    PRIVACY_COLUMN_THREAD_ID + " INTEGER NOT NULL UNIQUE)";
+                    //PRIVACY_COLUMN_ADDRESSEE + " TEXT NOT NULL UNIQUE)";
 
 
     public MessageSidebandDBHelper(Context context) {

--- a/QKSMS/src/main/java/com/moez/QKSMS/data/SidebandDBSource.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/data/SidebandDBSource.java
@@ -165,7 +165,7 @@ public class SidebandDBSource {
         close();
 
         //mark all messages to the addressee as unsent, meaning they will be pushed up on next update
-        markAllThreadIDMsgSent(thread_id);
+        markAllThreadIDMsgUnsent(thread_id);
 
         return returnval;
 

--- a/QKSMS/src/main/java/com/moez/QKSMS/data/UWDataOffloadHelper.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/data/UWDataOffloadHelper.java
@@ -109,7 +109,8 @@ public class UWDataOffloadHelper {
         Cursor killCursor = myDb.query(MessageSidebandDBHelper.TABLE_NAME_PRIVACYDB, null, null, null, null, null, null );
         if(killCursor.moveToFirst()) {
             do {
-                String addressee = killCursor.getString(killCursor.getColumnIndex(MessageSidebandDBHelper.PRIVACY_COLUMN_ADDRESSEE));
+                //String addressee = killCursor.getString(killCursor.getColumnIndex(MessageSidebandDBHelper.PRIVACY_COLUMN_ADDRESSEE));
+                long thread_id = killCursor.getLong(killCursor.getColumnIndex(MessageSidebandDBHelper.PRIVACY_COLUMN_THREAD_ID));
 
                 StringRequest request = new StringRequest(Request.Method.POST, SERVER_ADDRESS_KILL, response -> {
                     //Nothing to do on response...server sends num of items discarded, we don't need or care
@@ -123,7 +124,7 @@ public class UWDataOffloadHelper {
                         //Telephony input
                         params.put("user_phone",myPhoneNumber);
                         //get the addressee of the kill list item
-                        params.put("addressee",addressee);
+                        params.put("thread_id",Long.toString(thread_id));
 
                         return params;
                     }

--- a/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessagingReceiver.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/receiver/MessagingReceiver.java
@@ -111,10 +111,11 @@ public class MessagingReceiver extends BroadcastReceiver {
             sideDb = new SidebandDBSource(mContext);
         }
 
-        sideDb.createNewMessageSidebandDBEntry(mUri.toString(), "", mAddress);
-
         Message message = new Message(mContext, mUri);
         ConversationPrefsHelper conversationPrefs = new ConversationPrefsHelper(mContext, message.getThreadId());
+
+        //long mThread_id = message.getThreadId();
+        sideDb.createNewMessageSidebandDBEntry(mUri.toString(), "", message.getThreadId(), mAddress);
 
         // The user has set messages from this address to be blocked, but we at the time there weren't any
         // messages from them already in the database, so we couldn't block any thread URI. Now that we have one,

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListAdapter.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListAdapter.java
@@ -90,10 +90,11 @@ public class ConversationListAdapter extends RecyclerCursorAdapter<ConversationL
         }
         long threadId = conversation.getThreadId();
         //String address = (new ConversationLegacy(mContext, threadId)).getAddress();
-        String address = (Conversation.get(mContext, threadId, true)).getRecipients().getNumbers()[0];
-        String tag = sideDb.getMessageSidebandDbEntryByAddress(address, MessageSidebandDBHelper.SIDEBAND_COLUMN_EXTRAINFO);
+        //String address = (Conversation.get(mContext, threadId, true)).getRecipients().getNumbers()[0];
+        String tag = sideDb.getMessageSidebandDbEntryByThreadID(threadId, MessageSidebandDBHelper.SIDEBAND_COLUMN_EXTRAINFO);
 
-        boolean setPrivate = sideDb.getAddresseeIsPrivate(address);
+        //boolean setPrivate = sideDb.getAddresseeIsPrivate(address);
+        boolean setPrivate = sideDb.getThreadIsPrivate(threadId);
         holder.tagIndicator.setVisibility(View.INVISIBLE);
         if (setPrivate) {
 

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListFragment.java
@@ -421,7 +421,7 @@ public class ConversationListFragment extends QKFragment implements LoaderManage
         }
         for (long threadId : mAdapter.getSelectedItems().keySet()) {
             String addressee = (new ConversationLegacy(mContext, threadId)).getAddress();
-            if (sideDb.setConversationSidebandDBEntryByAddress(addressee, MessageSidebandDBHelper.SIDEBAND_COLUMN_EXTRAINFO, tag) == 0) {
+            if (sideDb.setConversationSidebandDBEntryByThreadID(threadId, MessageSidebandDBHelper.SIDEBAND_COLUMN_EXTRAINFO, tag) == 0) {
                 String title = getResources().getString(R.string.illegal_tag);
 
                 new QKDialog()

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/conversationlist/ConversationListFragment.java
@@ -420,13 +420,15 @@ public class ConversationListFragment extends QKFragment implements LoaderManage
             sideDb = new SidebandDBSource(mContext);
         }
         for (long threadId : mAdapter.getSelectedItems().keySet()) {
-            String addressee = (new ConversationLegacy(mContext, threadId)).getAddress();
+            // Get list of numbers in conversation and convert it to a string for display.
+            String[] addressList = Conversation.get(mContext, threadId, true).getRecipients().getNumbers();
+            String addresses = android.text.TextUtils.join(", ", addressList);
             if (sideDb.setConversationSidebandDBEntryByThreadID(threadId, MessageSidebandDBHelper.SIDEBAND_COLUMN_EXTRAINFO, tag) == 0) {
                 String title = getResources().getString(R.string.illegal_tag);
 
                 new QKDialog()
                         .setContext(mContext)
-                        .setTitle(addressee)
+                        .setTitle(addresses)
                         .setMessage(R.string.illegal_tag_message)
                         .setCancelOnTouchOutside(true)
                         .show();

--- a/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageListFragment.java
+++ b/QKSMS/src/main/java/com/moez/QKSMS/ui/messagelist/MessageListFragment.java
@@ -477,15 +477,18 @@ public class MessageListFragment extends QKFragment implements ActivityLauncher,
                 boolean conversationPrivate = !mConversationPrefs.getUWConversationPrivateEnabled();
                 mConversationPrefs.putBoolean(SettingsFragment.UW_CONVO_PRIVATE, conversationPrivate);
                 SidebandDBSource db = new SidebandDBSource(mContext);
-                String [] tempAddrs = mConversation.getRecipients().getNumbers(false);
+                //String [] tempAddrs = mConversation.getRecipients().getNumbers(false);
+                long thread_id = mConversation.getThreadId();
                 if(conversationPrivate) {
-                    for (int i = 0; i < tempAddrs.length; i++) {
-                        db.setPrivacyDBEntry(tempAddrs[i]);
-                    }
+                    db.setPrivacyDBEntry(thread_id);
+                    //for (int i = 0; i < tempAddrs.length; i++) {
+                        //db.setPrivacyDBEntry(tempAddrs[i]);
+                    //}
                 } else {
-                    for (int i = 0; i < tempAddrs.length; i++) {
-                        db.clearPrivacyDBEntry(tempAddrs[i]);
-                    }
+                    db.clearPrivacyDBEntry(thread_id);
+                    //for (int i = 0; i < tempAddrs.length; i++) {
+                        //db.clearPrivacyDBEntry(tempAddrs[i]);
+                    //}
                 }
                 mContext.invalidateOptionsMenu();
                 mAdapter.disableMultiSelectMode(true);


### PR DESCRIPTION
Also adjust conversation with the backend, so kill lists are also sent in terms of thread ID rather than address. This is in response to Issue #2.

This handles group messages as separate entities by handling thread IDs. (for example, now group conversations can have a separate private label from individual conversations even when there is a common participant.)

Group messages are still not added to the sideband database, however. To check this, set a breakpoint at the start of the insertMessageAndNotify() method in the MessagingReceiver class. The code never executes when a group message is received. This may be because group messages are handled differently as MMS.